### PR TITLE
feat(gitops/krmc): support passing flags to kustomize with `--kustomize-flags`

### DIFF
--- a/gitops/krmc.sh
+++ b/gitops/krmc.sh
@@ -41,10 +41,6 @@ find_kustomization_files() {
 
 # Build
 build() {
-  local kustomize_flags=(
-    "--load-restrictor=$kustomize_load_restrictor"
-  )
-
   find_kustomization_files "$1" | while IFS= read -r -d $'\0' file;
     do
       working_dir=$(dirname "$file")
@@ -53,7 +49,7 @@ build() {
       purple "$working_dir"
 
       set +e
-      output=$(kustomize build "$working_dir" "${kustomize_flags[@]}" 2>&1)
+      output=$(kustomize build "$working_dir" "$kustomize_flags" 2>&1)
       outcome=${PIPESTATUS[0]}
       set -e
 
@@ -153,6 +149,7 @@ user_manual() {
   echo "Flags:"
   printf "  --kubernetes-version\t\tThe kubernetes version to validate against. (default: 1.27.4)\n"
   printf "  --kustomize-load-restrictor\tThe kustomize load restrictor to use. (default: LoadRestrictionsNone)\n"
+  printf "  --kustomize-flags\t\tThe kustomize flags to use. (default: --load-restrictor=LoadRestrictionsNone)\n"
   printf "  --trivy-severity\t\tThe trivy severity to fail on. (default: HIGH,CRITICAL,MEDIUM)\n"
   printf "  --trivy-ignorefile\t\tThe trivy ignorefile to use. (default: .trivyignore)\n"
   printf "  --help\t\t\tHelp for krmc usage.\n"
@@ -167,6 +164,7 @@ print_settings() {
   echo
   printf "kubernetes-version:\t\t%s\n" "$kubernetes_version"
   printf "kustomize-load-restrictor:\t%s\n" "$kustomize_load_restrictor"
+  printf "kustomize-flags:\t\t\t%s\n" "$kustomize_flags"
   printf "trivy-severity:\t\t\t%s\n" "$trivy_severity"
   printf "trivy-ignorefile:\t\t%s\n" "$trivy_ignorefile"
   echo
@@ -179,6 +177,7 @@ main() {
   export command="help"
   export working_dir=()
   export kustomize_load_restrictor="LoadRestrictionsNone"
+  export kustomize_flags="--load-restrictor=LoadRestrictionsNone"
   export kubernetes_version="1.27.4"
   export trivy_severity="HIGH,CRITICAL,MEDIUM"
   export trivy_ignorefile=".trivyignore"
@@ -210,6 +209,10 @@ main() {
         ;;
       --kustomize-load-restrictor=*)
         kustomize_load_restrictor="${arg#*=}"
+        shift # past argument=value
+        ;;
+      --kustomize-flags=*)
+        kustomize_flags="${arg#*=}"
         shift # past argument=value
         ;;
       --trivy-severity=*)

--- a/gitops/krmc.sh
+++ b/gitops/krmc.sh
@@ -148,7 +148,6 @@ user_manual() {
   echo
   echo "Flags:"
   printf "  --kubernetes-version\t\tThe kubernetes version to validate against. (default: 1.27.4)\n"
-  printf "  --kustomize-load-restrictor\tThe kustomize load restrictor to use. (default: LoadRestrictionsNone)\n"
   printf "  --kustomize-flags\t\tThe kustomize flags to use. (default: --load-restrictor=LoadRestrictionsNone)\n"
   printf "  --trivy-severity\t\tThe trivy severity to fail on. (default: HIGH,CRITICAL,MEDIUM)\n"
   printf "  --trivy-ignorefile\t\tThe trivy ignorefile to use. (default: .trivyignore)\n"
@@ -159,14 +158,13 @@ user_manual() {
 print_settings() {
   purple "KRMC (Kubernetes Resource Model Checker):"
   echo
-  printf "command:\t\t\t%s\n" "$command"
-  printf "working dir:\t\t\t%s\n" "${working_dir[@]}"
+  printf "command:\t\t%s\n" "$command"
+  printf "working dir:\t\t%s\n" "${working_dir[@]}"
   echo
-  printf "kubernetes-version:\t\t%s\n" "$kubernetes_version"
-  printf "kustomize-load-restrictor:\t%s\n" "$kustomize_load_restrictor"
-  printf "kustomize-flags:\t\t\t%s\n" "$kustomize_flags"
-  printf "trivy-severity:\t\t\t%s\n" "$trivy_severity"
-  printf "trivy-ignorefile:\t\t%s\n" "$trivy_ignorefile"
+  printf "kubernetes-version:\t%s\n" "$kubernetes_version"
+  printf "kustomize-flags:\t%s\n" "$kustomize_flags"
+  printf "trivy-severity:\t\t%s\n" "$trivy_severity"
+  printf "trivy-ignorefile:\t%s\n" "$trivy_ignorefile"
   echo
 }
 
@@ -176,7 +174,6 @@ main() {
   # options
   export command="help"
   export working_dir=()
-  export kustomize_load_restrictor="LoadRestrictionsNone"
   export kustomize_flags="--load-restrictor=LoadRestrictionsNone"
   export kubernetes_version="1.27.4"
   export trivy_severity="HIGH,CRITICAL,MEDIUM"
@@ -205,10 +202,6 @@ main() {
     case $arg in
       --kubernetes-version=*)
         kubernetes_version="${arg#*=}"
-        shift # past argument=value
-        ;;
-      --kustomize-load-restrictor=*)
-        kustomize_load_restrictor="${arg#*=}"
         shift # past argument=value
         ;;
       --kustomize-flags=*)


### PR DESCRIPTION
krmc: support passing flags to kustomize with `--kustomize-flags`, therefore `--kustomize-load-restrictor` has been removed.